### PR TITLE
Improvements to the `dev` command

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -174,7 +174,6 @@ const runSite = async (command: Command, port: string) => {
   })
   onuStudioProcess.stdout.on('data', async (data: any) => {
     const output = data.toString()
-    // console.log(output)
     if (output.includes('started server on')) {
       console.log(
         chalk.green(`Onu Studio is available at http://localhost:${port}`),

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -152,6 +152,13 @@ const runSite = async (command: Command, port: string) => {
   onuDevJson.env = onuDevJson.env || {}
   shell.cd(CLIENT_PATH)
 
+  for (const key in onuDevJson.env) {
+    // if the value if an object, stringify it
+    if (typeof onuDevJson.env[key] === 'object') {
+      onuDevJson.env[key] = JSON.stringify(onuDevJson.env[key])
+    }
+  }
+
   const onuStudioProcess = childProcess.spawn('npm run dev', {
     env: {
       ...process.env,

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -114,7 +114,8 @@ const runDevStudio = async (command: Command, port: string | undefined, tsconfig
   if (isTypescript) {
     // compile the files
     const tsConfigFilePath = tsconfig || 'tsconfig.json'
-    const typescriptProcess = childProcess.spawnSync(`npx tsc -p ${tsConfigFilePath}`, ['--outDir', TS_FILES_DIST_PATH], {
+    const tscAliasCommand = `&& npx --yes tsc-alias -p ${tsConfigFilePath} --outDir ${TS_FILES_DIST_PATH}`
+    const typescriptProcess = childProcess.spawnSync(`npx --yes tsc -p ${tsConfigFilePath} --outDir ${TS_FILES_DIST_PATH} ${tscAliasCommand}`, [], {
       shell: true,
       cwd: CMD_EXEC_PATH,
       stdio: 'pipe',
@@ -123,6 +124,7 @@ const runDevStudio = async (command: Command, port: string | undefined, tsconfig
     if (typescriptProcess.status !== 0) {
       ux.action.stop()
       console.log(typescriptProcess.stdout.toString())
+      console.log(typescriptProcess.stderr.toString())
       console.log('There was an error compiling your Typescript files')
       command.exit(1)
     }
@@ -172,7 +174,7 @@ const runSite = async (command: Command, port: string) => {
   })
   onuStudioProcess.stdout.on('data', async (data: any) => {
     const output = data.toString()
-    console.log(output)
+    // console.log(output)
     if (output.includes('started server on')) {
       console.log(
         chalk.green(`Onu Studio is available at http://localhost:${port}`),
@@ -189,9 +191,8 @@ const runSite = async (command: Command, port: string) => {
     console.log(output)
   })
   const onExit = () => {
-    command.log('Exiting Onu Studio')
+    command.log(chalk.magenta('\n✨ Successfully exited Onu Studio\n'))
     onuStudioProcess.kill('SIGINT')
-    command.exit(0)
   }
 
   process.on('SIGINT', onExit)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -119,7 +119,7 @@ export default class Init extends Command {
         packageJson.scripts.build = 'npx tsc'
 
         // add a dev script
-        packageJson.scripts.dev = 'npx onu dev'
+        packageJson.scripts.dev = 'npx onu@latest dev'
 
         // add a start script
         packageJson.scripts.start = 'node dist/onu/index.js'
@@ -173,7 +173,7 @@ export default class Init extends Command {
         packageJson.dependencies['node-fetch'] = '^2.6.6'
 
         // add a dev script
-        packageJson.scripts.dev = 'npx onu dev'
+        packageJson.scripts.dev = 'npx onu@latest dev'
 
         // add a start script
         packageJson.scripts.start = 'node onu/index.js'


### PR DESCRIPTION
This PR fixes some issues with the dev command:

- If a user passes in an object as an env var value in `onu.dev.json`, we now stringify that value before exporting it as an env variable
- the subprocess now shuts down gracefully on SIGINT - before it would throw an error
- We automatically compile alias paths for typescript files now
- I updated the `dev` command in the package.json scripts to always attempt to use the latest version of the onu cli
- Only show warning and error logs from the underlying nextjs app when running onu studio